### PR TITLE
Add GC::Profiler support

### DIFF
--- a/lib/sigdump.rb
+++ b/lib/sigdump.rb
@@ -8,6 +8,7 @@ module Sigdump
           io.write "Sigdump at #{Time.now} process #{Process.pid} (#{$0})\n"
           dump_all_thread_backtrace(io)
           dump_object_count(io)
+          dump_gc_profiler_result(io)
         end
       rescue
       end
@@ -72,6 +73,17 @@ module Sigdump
     io.write "    Hash #{_fn(hash_size)} pairs\n"
 
     io.flush
+    nil
+  end
+
+  def self.dump_gc_profiler_result(io)
+    return unless defined?(GC::Profiler) && GC::Profiler.enabled?
+    io.write "  GC profiling result:\n"
+    io.write "  Total garbage collection time: %f\n" % GC::Profiler.total_time
+    GC::Profiler.result.each_line.map do |line|
+      io.write "  #{line}"
+    end
+    GC::Profiler.clear
     nil
   end
 


### PR DESCRIPTION
This PR adds GC::Profiler support.
It is only enabled when GC::Profile is enabled.
Using the following simple script, I confirmed this change is available on both ruby 1.9.3-p392 and 2.0.0-p0.

``` ruby
require 'sigdump/setup'
GC::Profiler.enable
a = Thread.new {
  100.times {
    a = Array.new(10000){ 'aa' }
    sleep 0.1
  }
}
b = Thread.new {
  100.times {
    a = Array.new(10000){ 'aa' }
    sleep 0.1
  }
}
5.times do
  Process.kill :CONT, Process.pid
  sleep 0.5
end
a.join
b.join
```
