### PR TITLE
Optimize dumping objects count

### DIFF
--- a/lib/sigdump.rb
+++ b/lib/sigdump.rb
@@ -71,16 +71,16 @@ module Sigdump
       string_size = 0
       array_size = 0
       hash_size = 0
-      cmap = {}
+      cmap = Hash.new(0).compare_by_identity
       ObjectSpace.each_object {|o|
-        c = o.class
-        cmap[c] = (cmap[c] || 0) + 1
+        c = o.class rescue nil
+        cmap[c] += 1
         if c == String
           string_size += o.bytesize
         elsif c == Array
-          array_size = o.size
+          array_size += o.size
         elsif c == Hash
-          hash_size = o.size
+          hash_size += o.size
         end
       }
 


### PR DESCRIPTION
Tested on a large heap - I got up to 3x speed improvement of this method.

```
Warming up --------------------------------------
          old_method     1.000  i/100ms
          new_method     2.000  i/100ms
Calculating -------------------------------------
          old_method      7.730  (± 0.0%) i/s -     39.000  in   5.045833s
          new_method     20.366  (± 0.0%) i/s -    102.000  in   5.009285s

Comparison:
          new_method:       20.4 i/s
          old_method:        7.7 i/s - 2.63x  slower
```

I love how this gem got 27m downloads and 0 tests 😄 